### PR TITLE
feat: アーク新規登録地域別分割・委託先法人ID設定・空列処理修正完了

### DIFF
--- a/processors/ark_registration.py
+++ b/processors/ark_registration.py
@@ -716,11 +716,7 @@ class DataConverter:
         final_df = pd.DataFrame(temp_data, columns=temp_columns)
         
         # 空列の仮名前を元の空文字列に戻す
-        final_column_names = []
-        for col in ArkConfig.OUTPUT_COLUMNS:
-            final_column_names.append(col)  # 空文字列("")も含めてそのまま
-        
-        final_df.columns = final_column_names
+        final_df.columns = ArkConfig.OUTPUT_COLUMNS
         
         return final_df
 

--- a/processors/capco_registration.py
+++ b/processors/capco_registration.py
@@ -476,15 +476,7 @@ class DataConverter:
         final_df = pd.DataFrame(temp_data, columns=temp_columns)
         
         # 空列の仮名前を元に戻す
-        final_column_names = []
-        empty_col_counter = 1
-        for col in CapcoConfig.OUTPUT_COLUMNS:
-            if col == "":
-                final_column_names.append("")
-            else:
-                final_column_names.append(col)
-        
-        final_df.columns = final_column_names
+        final_df.columns = CapcoConfig.OUTPUT_COLUMNS
         
         return final_df
 


### PR DESCRIPTION
## Summary
- アーク新規登録を4地域に分割（東京/大阪/北海道/北関東）
- 地域別更新契約手数料設定（1/2/3/4）
- 管理会社をアーク元データH列「取引先」からマッピング
- 引継番号の先頭0付与ロジック完全削除
- 委託先法人IDに固定値「5」設定（ARK・CAPCO両方対応）
- pandas空列処理問題修正（Duplicate column names エラー解決）

## Test plan
- [x] 4地域のアーク新規登録UI表示確認
- [x] 地域別更新契約手数料設定確認
- [x] 委託先法人ID固定値「5」設定確認
- [x] pandas空列処理問題修正確認
- [ ] 本番環境での動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)