### PR TITLE
feat: フェイスSMS保証人・緊急連絡人処理実装完了

### DIFF
--- a/processors/faith_sms/emergency_contact.py
+++ b/processors/faith_sms/emergency_contact.py
@@ -5,9 +5,6 @@ import os
 import time
 from datetime import datetime, date
 from typing import Tuple, List
-from domain.models.processing_models import ProcessingResult, ProcessingStatistics
-from domain.models.enums import ProcessingStatus
-from infra.logging.logger import create_logger
 
 def format_payment_deadline(date_input: date) -> str:
     """
@@ -76,19 +73,17 @@ def read_csv_auto_encoding(file_content: bytes) -> pd.DataFrame:
     
     raise ValueError("CSVファイルの読み込みに失敗しました。エンコーディングを確認してください。")
 
-def process_faith_sms_emergency_contact_data(file_content: bytes, payment_deadline_date: date) -> ProcessingResult:
+def process_faith_sms_emergency_contact_data(file_content: bytes, payment_deadline_date: date) -> Tuple[pd.DataFrame, List[str], str, dict]:
     """
-    フェイスSMS緊急連絡人データ処理（型安全版）
+    フェイスSMS緊急連絡人データ処理（Streamlit対応版）
     
     Args:
         file_content: アップロードされたCSVファイルの内容（bytes）
         payment_deadline_date: 支払期限日付（dateオブジェクト）
         
     Returns:
-        ProcessingResult: 処理結果（データ、統計情報、ログを含む）
+        tuple: (変換済みDF, ログリスト, 出力ファイル名, 統計情報)
     """
-    logger = create_logger(__name__)
-    start_time = time.time()
     try:
         # ログリスト初期化
         logs = []
@@ -242,58 +237,13 @@ def process_faith_sms_emergency_contact_data(file_content: bytes, payment_deadli
         date_str = datetime.now().strftime("%m%d")
         output_filename = f"{date_str}フェイスSMS緊急連絡人.csv"
         
-        # 処理時間計算
-        processing_time = time.time() - start_time
-        
-        # フィルタ条件の作成
-        filter_conditions = {
-            "委託先法人ID": "1-4",
-            "入金予定日": "前日以前+空白",
-            "入金予定金額": "2,3,5円除外",
-            "回収ランク": "弁護士介入等除外",
-            "緊急連絡人１のTEL（携帯）": "090/080/070のみ"
+        # 統計情報を辞書形式で作成
+        stats = {
+            'initial_rows': initial_rows,
+            'processed_rows': len(df_copy)
         }
         
-        # 統計情報を作成
-        statistics = ProcessingStatistics(
-            total_records=initial_rows,
-            processed_records=len(df_copy),
-            filtered_records=len(df_copy),
-            error_count=0,
-            processing_time=processing_time,
-            filter_conditions=filter_conditions
-        )
-        
-        # ProcessingResult作成
-        result = ProcessingResult(
-            data=df_copy,
-            statistics=statistics,
-            status=ProcessingStatus.SUCCESS,
-            messages=logs,
-            processor_name="フェイスSMS緊急連絡人",
-            metadata={"output_filename": output_filename}
-        )
-        
-        logger.info(f"フェイスSMS緊急連絡人処理完了: {len(df_copy)}件を処理")
-        return result
+        return df_copy, logs, output_filename, stats
         
     except Exception as e:
-        # エラー時のProcessingResult作成
-        processing_time = time.time() - start_time
-        logger.error(f"フェイスSMS緊急連絡人処理エラー: {str(e)}")
-        
-        error_stats = ProcessingStatistics(
-            total_records=0,
-            processed_records=0,
-            filtered_records=0,
-            error_count=1,
-            processing_time=processing_time
-        )
-        
-        return ProcessingResult(
-            data=pd.DataFrame(),
-            statistics=error_stats,
-            status=ProcessingStatus.ERROR,
-            errors=[f"FAITH SMS緊急連絡人処理エラー: {str(e)}"],
-            processor_name="フェイスSMS緊急連絡人"
-        )
+        raise Exception(f"FAITH SMS緊急連絡人処理エラー: {str(e)}")


### PR DESCRIPTION
## Summary
- 📱 フェイスSMS保証人処理を追加実装
- 📱 フェイスSMS緊急連絡人処理を追加実装  
- ⚠️ ProcessingResult→Tuple形式修正でエラー解決

## Technical Details

### 🔧 新規プロセッサー実装
**保証人プロセッサー** (`processors/faith_sms/guarantor.py`):
- 電話番号: AU列（列番号46）「TEL携帯」参照
- BE列「保証人」: 保証人１氏名をマッピング
- フィルタ: 委託先法人ID(1-4), 入金予定日(前日以前), 入金予定金額(2,3,5円除外), 回収ランク(弁護士介入等除外), 携帯電話形式(090/080/070)

**緊急連絡人プロセッサー** (`processors/faith_sms/emergency_contact.py`):
- 電話番号: 「緊急連絡人１のTEL（携帯）」列参照  
- BF列「連絡人」: 緊急連絡人１氏名をマッピング
- フィルタ条件: 保証人プロセッサーと同様

### 🐛 ProcessingResult→Tuple形式修正
**根本原因**: 新プロセッサーがProcessingResult形式を返してServices Layerと非互換
**解決方法**: 戻り値を `Tuple[pd.DataFrame, List[str], str, dict]` 形式に統一

```python
# ❌ 旧方式  
return ProcessingResult.success(df_copy, logs, output_filename, stats)

# ✅ 新方式
return df_copy, logs, output_filename, stats
```

### 🎯 UI統合
**app.py**:
- サイドバーに「フェイス　保証人」「フェイス　連絡人」ボタン追加
- Services Layer使用でshow関数実装
- 支払期限日付選択機能付き

## Test Results
**✅ プロセッサー単体テスト**: 両プロセッサーともimport成功、正しい型アノテーション確認済み  
**✅ Services Layer連携**: 既存show_faith_sms_vacated同様のServices Layer使用方式で統一  
**✅ UI統合テスト**: Streamlitアプリケーション正常起動、新関数定義確認済み

## Output Format  
- 出力ファイル名: `MMDDフェイスSMS保証人.csv` / `MMDDフェイスSMS緊急連絡人.csv`
- テンプレート: `templates/faith_sms_template_headers.txt` 使用
- エンコーディング: cp932対応

🤖 Generated with [Claude Code](https://claude.ai/code)