### PR TITLE
feat: フェイスSMS緊急連絡人機能実装完了

### DIFF
--- a/app.py
+++ b/app.py
@@ -90,6 +90,7 @@ from processors.plaza_autocall.contact.standard import process_plaza_contact_dat
 
 from processors.faith_sms.vacated_contract import process_faith_sms_vacated_contract_data
 from processors.faith_sms.guarantor import process_faith_sms_guarantor_data
+from processors.faith_sms.emergency_contact import process_faith_sms_emergency_contact_data
 from processors.ark_registration import process_ark_data, process_arktrust_data
 from processors.ark_late_payment_update import process_ark_late_payment_data
 from processors.capco_registration import process_capco_data
@@ -261,6 +262,8 @@ def main():
             st.session_state.selected_processor = "faith_sms_vacated"
         if st.button("フェイス　保証人", key="faith_sms_guarantor", use_container_width=True):
             st.session_state.selected_processor = "faith_sms_guarantor"
+        if st.button("フェイス　連絡人", key="faith_sms_emergency_contact", use_container_width=True):
+            st.session_state.selected_processor = "faith_sms_emergency_contact"
         
         # 📋 新規登録用CSV加工
         st.markdown('<div class="sidebar-category">📋 新規登録用CSV加工</div>', unsafe_allow_html=True)
@@ -338,6 +341,8 @@ def main():
         show_faith_sms_vacated()
     elif st.session_state.selected_processor == "faith_sms_guarantor":
         show_faith_sms_guarantor()
+    elif st.session_state.selected_processor == "faith_sms_emergency_contact":
+        show_faith_sms_emergency_contact()
     elif st.session_state.selected_processor == "ark_registration_tokyo":
         show_ark_registration_tokyo()
     elif st.session_state.selected_processor == "ark_registration_osaka":
@@ -542,6 +547,71 @@ def show_faith_sms_guarantor():
                     st.markdown("• 入金予定金額 → 2,3,5円除外")
                     st.markdown("• 回収ランク → 「弁護士介入」「破産決定」「死亡決定」除外")
                     st.markdown("• AU列TEL携帯 → 090/080/070形式のみ（保証人電話番号）")
+                    st.markdown('</div>', unsafe_allow_html=True)
+        except Exception as e:
+            st.error(f"エラーが発生しました: {str(e)}")
+
+def show_faith_sms_emergency_contact():
+    st.header("📱 フェイス　連絡人")
+    
+    # 支払期限日付入力
+    st.subheader("支払期限の設定")
+    payment_deadline_date = st.date_input(
+        "クリックして支払期限を選択してください",
+        value=date.today(),  # デフォルト値: 今日の日付
+        help="この日付がBG列「支払期限」に設定されます（例：2025年6月30日）",
+        key="faith_sms_emergency_contact_payment_deadline",
+        disabled=False,  # カレンダー選択は有効
+        format="YYYY/MM/DD"
+    )
+    st.write(f"設定される支払期限: **{payment_deadline_date.strftime('%Y年%m月%d日')}**")
+    
+    uploaded_file = st.file_uploader("CSVファイルをアップロードしてください", type="csv", key="faith_sms_emergency_contact_file")
+    
+    if uploaded_file is not None:
+        try:
+            st.success(f"✅ {uploaded_file.name}: 読み込み完了")
+            
+            if st.button("処理を実行", type="primary", key="faith_sms_emergency_contact_process"):
+                with st.spinner("処理中..."):
+                    # 戻り値を一時変数で受け取る
+                    result = process_faith_sms_emergency_contact_data(uploaded_file.read(), payment_deadline_date)
+                    result_df, logs, filename, stats = result
+                    
+                if not result_df.empty:
+                    st.success(f"処理完了: {stats['processed_rows']}件のデータを出力（元データ: {stats['initial_rows']}件）")
+                    safe_csv_download(result_df, filename)
+                    
+                    # 処理ログ表示（データの有無に関わらず表示）
+                    with st.expander("📊 処理ログ", expanded=False):
+                        for log in logs:
+                            st.write(f"• {log}")
+                    
+                    # フィルタ条件表示
+                    st.markdown("**フィルタ条件:**")
+                    st.markdown('<div class="filter-condition">', unsafe_allow_html=True)
+                    st.markdown("• 委託先法人ID → 1-4")
+                    st.markdown("• 入金予定日 → 前日以前とNaN")
+                    st.markdown("• 入金予定金額 → 2,3,5円除外")
+                    st.markdown("• 回収ランク → 「弁護士介入」「破産決定」「死亡決定」除外")
+                    st.markdown("• BE列「緊急連絡人１のTEL携帯」 → 090/080/070形式のみ")
+                    st.markdown('</div>', unsafe_allow_html=True)
+                else:
+                    st.warning("条件に合致するデータがありませんでした。")
+                    
+                    # 処理ログ表示（エラー時も表示）
+                    with st.expander("📊 処理ログ", expanded=True):
+                        for log in logs:
+                            st.write(f"• {log}")
+                    
+                    # フィルタ条件表示
+                    st.markdown("**フィルタ条件:**")
+                    st.markdown('<div class="filter-condition">', unsafe_allow_html=True)
+                    st.markdown("• 委託先法人ID → 1-4")
+                    st.markdown("• 入金予定日 → 前日以前とNaN")
+                    st.markdown("• 入金予定金額 → 2,3,5円除外")
+                    st.markdown("• 回収ランク → 「弁護士介入」「破産決定」「死亡決定」除外")
+                    st.markdown("• BE列「緊急連絡人１のTEL携帯」 → 090/080/070形式のみ")
                     st.markdown('</div>', unsafe_allow_html=True)
         except Exception as e:
             st.error(f"エラーが発生しました: {str(e)}")

--- a/processors/faith_sms/emergency_contact.py
+++ b/processors/faith_sms/emergency_contact.py
@@ -1,0 +1,248 @@
+import pandas as pd
+import io
+import re
+import os
+from datetime import datetime, date
+from typing import Tuple, List
+
+def format_payment_deadline(date_input: date) -> str:
+    """
+    日付オブジェクトを日本語形式に変換
+    
+    Args:
+        date_input: datetimeのdateオブジェクト
+        
+    Returns:
+        str: 'YYYY年MM月DD日' 形式の文字列
+        
+    Examples:
+        format_payment_deadline(date(2025, 6, 30)) -> '2025年6月30日'
+        format_payment_deadline(date(2025, 12, 1)) -> '2025年12月1日'
+    """
+    return date_input.strftime("%Y年%m月%d日")
+
+def load_faith_sms_template_headers() -> List[str]:
+    """外部ファイルからフェイスSMSテンプレートヘッダーを読み込み"""
+    # 複数のパス候補を試行
+    current_dir = os.path.dirname(__file__)
+    
+    # パス候補リスト
+    template_paths = [
+        os.path.join(current_dir, '..', '..', 'templates', 'faith_sms_template_headers.txt'),  # 相対パス
+        os.path.abspath(os.path.join(current_dir, '..', '..', 'templates', 'faith_sms_template_headers.txt')),  # 絶対パス
+        'templates/faith_sms_template_headers.txt',  # カレントディレクトリから
+        './templates/faith_sms_template_headers.txt',  # カレントディレクトリから
+    ]
+    
+    # 各パスを試行
+    for template_path in template_paths:
+        if os.path.exists(template_path):
+            try:
+                # 複数のエンコーディングで試行
+                encodings = ['utf-8', 'utf-8-sig', 'cp932', 'shift_jis']
+                header_line = None
+                
+                for encoding in encodings:
+                    try:
+                        with open(template_path, 'r', encoding=encoding) as f:
+                            header_line = f.read().strip()
+                        break
+                    except UnicodeDecodeError:
+                        continue
+                        
+                if header_line is None:
+                    raise Exception("ヘッダーファイルの読み込みに失敗しました（エンコーディングエラー）")
+                    
+                return header_line.split(',')
+            except Exception as e:
+                continue  # 次のパスを試行
+    
+    # すべてのパスで失敗した場合
+    raise FileNotFoundError(f"SMSテンプレートヘッダーファイルが見つかりません。試行パス: {template_paths}")
+
+def read_csv_auto_encoding(file_content: bytes) -> pd.DataFrame:
+    """アップロードされたCSVファイルを自動エンコーディング判定で読み込み"""
+    encodings = ['utf-8', 'utf-8-sig', 'shift_jis', 'cp932', 'euc_jp']
+    
+    for enc in encodings:
+        try:
+            return pd.read_csv(io.BytesIO(file_content), encoding=enc, dtype=str)
+        except Exception:
+            continue
+    
+    raise ValueError("CSVファイルの読み込みに失敗しました。エンコーディングを確認してください。")
+
+def process_faith_sms_emergency_contact_data(file_content: bytes, payment_deadline_date: date) -> Tuple[pd.DataFrame, List[str], str, dict]:
+    """
+    フェイスSMS緊急連絡人データ処理（Streamlit対応版）
+    
+    Args:
+        file_content: アップロードされたCSVファイルの内容（bytes）
+        payment_deadline_date: 支払期限日付（dateオブジェクト）
+        
+    Returns:
+        tuple: (変換済みDF, ログリスト, 出力ファイル名, 統計情報)
+    """
+    try:
+        # ログリスト初期化
+        logs = []
+        
+        # CSVファイル読み込み（自動エンコーディング判定）
+        df = read_csv_auto_encoding(file_content)
+
+        initial_rows = len(df)
+        logs.append(f"元データ読み込み: {initial_rows}件")
+        
+        # Filter 1: 委託先法人ID (Keep only 1, 2, 3, 4)
+        trustee_ids_to_keep = [1, 2, 3, 4]
+        df['委託先法人ID'] = pd.to_numeric(df['委託先法人ID'], errors='coerce').fillna(-1).astype(int)
+        
+        # 除外データの詳細を記録
+        excluded_trustee = df[~df['委託先法人ID'].isin(trustee_ids_to_keep)]
+        if len(excluded_trustee) > 0:
+            excluded_ids = excluded_trustee['委託先法人ID'].value_counts().head(5).to_dict()
+            logs.append(f"フィルター1除外 - 委託先法人ID詳細: {excluded_ids}")
+        
+        df = df[df['委託先法人ID'].isin(trustee_ids_to_keep)]
+        logs.append(f"フィルター1 - 委託先法人ID(1-4): {len(df)}件")
+        
+        # Filter 2: 入金予定日 (Keep empty or dates before today)
+        df['入金予定日'] = pd.to_datetime(df['入金予定日'], format='%Y/%m/%d', errors='coerce')
+        today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        
+        # 除外データの詳細を記録
+        excluded_dates = df[~(df['入金予定日'].isna() | (df['入金予定日'] < today))]
+        if len(excluded_dates) > 0:
+            future_dates = excluded_dates['入金予定日'].dropna().dt.strftime('%Y/%m/%d').value_counts().head(3).to_dict()
+            logs.append(f"フィルター2除外 - 未来日付例: {future_dates}")
+        
+        df = df[df['入金予定日'].isna() | (df['入金予定日'] < today)]
+        logs.append(f"フィルター2 - 入金予定日(前日以前+空白): {len(df)}件")
+        
+        # Filter 3: 入金予定金額 (Exclude specific amounts: 2, 3, 5 as numeric or string values)
+        payment_amount_exclude_numeric = [2, 3, 5]
+        payment_amount_exclude_string = ["2", "3", "5"]
+        df['入金予定金額_numeric'] = pd.to_numeric(df['入金予定金額'], errors='coerce')
+        df['入金予定金額_string'] = df['入金予定金額'].astype(str)
+        
+        # 除外データの詳細を記録
+        excluded_amounts = df[(df['入金予定金額_numeric'].isin(payment_amount_exclude_numeric) | 
+                              df['入金予定金額_string'].isin(payment_amount_exclude_string))]
+        if len(excluded_amounts) > 0:
+            excluded_values = excluded_amounts['入金予定金額'].value_counts().head(3).to_dict()
+            logs.append(f"フィルター3除外 - 金額詳細: {excluded_values}")
+        
+        df = df[~(df['入金予定金額_numeric'].isin(payment_amount_exclude_numeric) | 
+                  df['入金予定金額_string'].isin(payment_amount_exclude_string))]
+        df = df.drop(['入金予定金額_numeric', '入金予定金額_string'], axis=1)
+        logs.append(f"フィルター3 - 入金予定金額(2,3,5円除外): {len(df)}件")
+        
+        # Filter 4: 回収ランク (Exclude specific ranks)
+        collection_rank_exclude = ["弁護士介入", "破産決定", "死亡決定"]
+        
+        # 除外データの詳細を記録
+        excluded_ranks = df[df['回収ランク'].isin(collection_rank_exclude)]
+        if len(excluded_ranks) > 0:
+            excluded_rank_counts = excluded_ranks['回収ランク'].value_counts().to_dict()
+            logs.append(f"フィルター4除外 - 回収ランク詳細: {excluded_rank_counts}")
+        
+        df = df[~df['回収ランク'].isin(collection_rank_exclude)]
+        logs.append(f"フィルター4 - 回収ランク(弁護士介入等除外): {len(df)}件")
+        
+        # Filter 5: BE列「緊急連絡人１のTEL携帯」 (Keep only valid mobile phone numbers) - 列番号57を使用
+        mobile_phone_regex = r'^(090|080|070)-\d{4}-\d{4}$'
+        
+        # BE列（列番号57）の電話番号を取得
+        emergency_phone_series = df.iloc[:, 57].astype(str).str.strip().replace('nan', '')
+        
+        def is_mobile_phone(phone_number):
+            if phone_number == '':
+                return False
+            return bool(re.match(mobile_phone_regex, phone_number))
+        
+        # 除外データの詳細を記録
+        excluded_phones_mask = ~emergency_phone_series.apply(is_mobile_phone)
+        if excluded_phones_mask.sum() > 0:
+            invalid_phone_samples = emergency_phone_series[excluded_phones_mask].value_counts().head(5).to_dict()
+            logs.append(f"フィルター5除外 - BE列「緊急連絡人１のTEL携帯」形式例: {invalid_phone_samples}")
+        
+        df = df[emergency_phone_series.apply(is_mobile_phone)]
+        logs.append(f"フィルター5 - BE列「緊急連絡人１のTEL携帯」(090/080/070のみ): {len(df)}件")
+        
+        # Data mapping to output format - load from external template
+        output_column_order = load_faith_sms_template_headers()
+        
+        # Create temporary column names for DataFrame construction (to handle empty column names)
+        temp_column_order = []
+        empty_col_counter = 1
+        for col in output_column_order:
+            if col == "":
+                temp_column_order.append(f"_empty_{empty_col_counter}")
+                empty_col_counter += 1
+            else:
+                temp_column_order.append(col)
+        
+        # Create output DataFrame with temporary column names
+        output_df = pd.DataFrame(columns=temp_column_order)
+        
+        # Map data - BE列（列番号57）の電話番号を使用
+        output_df['電話番号'] = df.iloc[:, 57].astype(str)
+        output_df['(info1)契約者名'] = df['契約者氏名']
+        
+        # Combine property name and number
+        output_df['(info2)物件名'] = df['物件名'].astype(str) + df['物件番号'].fillna('').astype(str).apply(
+            lambda x: f'　{x}' if x and x != 'nan' else ''
+        )
+        
+        # Format amount with comma separation
+        df['滞納残債'] = df['滞納残債'].astype(str).str.replace(r'[^0-9,]', '', regex=True)
+        output_df['(info3)金額'] = pd.to_numeric(
+            df['滞納残債'].str.replace(',', ''), errors='coerce'
+        ).fillna(0).astype(int).apply(lambda x: f'{x:,}')
+        
+        # Combine bank account information with full-width spaces
+        output_df['(info4)銀行口座'] = (
+            df['回収口座銀行名'].astype(str) + '　' +
+            df['回収口座支店名'].astype(str) + '　' +
+            df['回収口座種類'].astype(str) + '　' +
+            df['回収口座番号'].astype(str).str.replace('="', '').str.replace('"', '') + '　' +
+            df['回収口座名義人'].astype(str)
+        )
+        
+        output_df['(info5)メモ'] = df['管理番号'].astype(str)
+        
+        # 連絡人列に緊急連絡人１氏名をマッピング
+        output_df['連絡人'] = df['緊急連絡人１氏名'].astype(str)
+        
+        # Set payment deadline (BG column - column 59)
+        payment_deadline_formatted = format_payment_deadline(payment_deadline_date)
+        output_df['支払期限'] = payment_deadline_formatted
+        
+        # Fill empty columns and other remaining columns
+        for col in temp_column_order:
+            if col.startswith('_empty_') and col not in output_df.columns:
+                output_df[col] = ''
+            elif col in ['保証人'] and col not in output_df.columns:
+                output_df[col] = ''
+        
+        # Ensure correct column order
+        output_df = output_df[temp_column_order]
+        
+        # Create output filename
+        date_str = datetime.now().strftime("%m%d")
+        output_filename = f"{date_str}フェイスSMS連絡人.csv"
+        
+        # Restore original column names from template (convert _empty_X back to blank)
+        df_copy = output_df.copy()
+        df_copy.columns = output_column_order
+        
+        # 統計情報を辞書形式で作成
+        stats = {
+            'initial_rows': initial_rows,
+            'processed_rows': len(output_df)
+        }
+        
+        return df_copy, logs, output_filename, stats
+        
+    except Exception as e:
+        raise Exception(f"FAITH SMS緊急連絡人処理エラー: {str(e)}")


### PR DESCRIPTION
## Summary
• BE列（列番号57）「緊急連絡人１のTEL携帯」を参照する緊急連絡人SMS処理を実装
• 保証人機能と同様のフィルタリング条件で、緊急連絡人用の連絡先データを出力
• UIに「フェイス　連絡人」ボタンを追加し、完全に統合

## Test plan
- [x] 緊急連絡人プロセッサーの動作確認済み
- [x] UIボタンの正常動作確認済み 
- [x] Streamlit起動・表示確認済み
- [x] BE列（列番号57）からの電話番号取得確認済み
- [x] 「連絡人」列への緊急連絡人１氏名マッピング確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)