### PR TITLE
feat: ミライル（フェイス封筒）差込み用リスト機能を追加

### DIFF
--- a/app.py
+++ b/app.py
@@ -103,6 +103,14 @@ from screens.notification.faith import (
     render_faith_e_excluded,
     render_faith_e_evicted
 )
+from screens.notification.mirail import (
+    show_mirail_contractor_145,
+    show_mirail_contractor_not145,
+    show_mirail_guarantor_145,
+    show_mirail_guarantor_not145,
+    show_mirail_contact_145,
+    show_mirail_contact_not145
+)
 
 # プロセッサーをインポート
 
@@ -164,7 +172,13 @@ def main():
         "faith_g_evicted": render_faith_g_evicted,
         "faith_e_litigation": render_faith_e_litigation,
         "faith_e_excluded": render_faith_e_excluded,
-        "faith_e_evicted": render_faith_e_evicted
+        "faith_e_evicted": render_faith_e_evicted,
+        "mirail_c_145": show_mirail_contractor_145,
+        "mirail_c_not145": show_mirail_contractor_not145,
+        "mirail_g_145": show_mirail_guarantor_145,
+        "mirail_g_not145": show_mirail_guarantor_not145,
+        "mirail_e_145": show_mirail_contact_145,
+        "mirail_e_not145": show_mirail_contact_not145
     }
     
     # カスタムCSSを適用

--- a/components/sidebar.py
+++ b/components/sidebar.py
@@ -109,7 +109,7 @@ def build_sidebar_menu():
         
         # 📝 差込み用リスト作成
         st.markdown('<div class="sidebar-category">📝 差込み用リスト作成</div>', unsafe_allow_html=True)
-        
+
         # フェイス差込み用リスト
         st.markdown('<div class="sidebar-subcategory">フェイス差込み用リスト</div>', unsafe_allow_html=True)
         if st.button("契約者「入居中」「訴訟中」", key="faith_c_litigation", use_container_width=True):
@@ -130,3 +130,18 @@ def build_sidebar_menu():
             st.session_state.selected_processor = "faith_e_excluded"
         if st.button("連絡人「退去済み」", key="faith_e_evicted", use_container_width=True):
             st.session_state.selected_processor = "faith_e_evicted"
+
+        # ミライル（フェイス封筒）
+        st.markdown('<div class="sidebar-subcategory">ミライル（フェイス封筒）</div>', unsafe_allow_html=True)
+        if st.button("契約者（1,4,5）", key="mirail_c_145", use_container_width=True):
+            st.session_state.selected_processor = "mirail_c_145"
+        if st.button("契約者（1,4,5以外）", key="mirail_c_not145", use_container_width=True):
+            st.session_state.selected_processor = "mirail_c_not145"
+        if st.button("保証人（1,4,5）", key="mirail_g_145", use_container_width=True):
+            st.session_state.selected_processor = "mirail_g_145"
+        if st.button("保証人（1,4,5以外）", key="mirail_g_not145", use_container_width=True):
+            st.session_state.selected_processor = "mirail_g_not145"
+        if st.button("連絡人（1,4,5）", key="mirail_e_145", use_container_width=True):
+            st.session_state.selected_processor = "mirail_e_145"
+        if st.button("連絡人（1,4,5以外）", key="mirail_e_not145", use_container_width=True):
+            st.session_state.selected_processor = "mirail_e_not145"

--- a/processors/mirail_notification.py
+++ b/processors/mirail_notification.py
@@ -6,7 +6,7 @@ import pandas as pd
 import numpy as np
 import io
 from datetime import datetime
-from typing import Tuple, Optional
+from typing import Tuple, Optional, List
 from processors.common.detailed_logger import DetailedLogger
 
 
@@ -27,7 +27,7 @@ def process_mirail_notification(
     file_content: bytes,
     target_type: str,  # 'contractor', 'guarantor', 'contact'
     client_pattern: str  # 'included' or 'excluded'
-) -> Tuple[Optional[pd.DataFrame], Optional[str], str, list]:
+) -> Tuple[Optional[pd.DataFrame], Optional[str], str, List[str]]:
     """
     ミライル（フェイス封筒）用リストを生成する
 
@@ -40,7 +40,7 @@ def process_mirail_notification(
         (result_df, filename, message, logs)
         0件の場合: (None, None, エラーメッセージ, logs)
     """
-    logger = DetailedLogger()
+    logs = []  # ログリスト
 
     try:
         # 処理開始
@@ -52,15 +52,11 @@ def process_mirail_notification(
         target_name = target_name_map.get(target_type, target_type)
         pattern_text = "（1,4,5）" if client_pattern == 'included' else "（1,4,5以外）"
 
-        logger.log(f"処理開始: {target_name}{pattern_text}")
-
         # CSV読み込み
-        logger.log("CSVファイル読み込み中...")
         df = read_csv_auto_encoding(file_content)
-        logger.log(f"入力データ: {len(df)}件, {len(df.columns)}列")
+        logs.append(DetailedLogger.log_initial_load(len(df)))
 
         # データ型変換
-        logger.log("データ型変換中...")
         df['委託先法人ID'] = pd.to_numeric(df['委託先法人ID'], errors='coerce')
         df['クライアントCD'] = pd.to_numeric(df['クライアントCD'], errors='coerce')
         df['入金予定金額'] = pd.to_numeric(df['入金予定金額'], errors='coerce')
@@ -69,8 +65,7 @@ def process_mirail_notification(
         # 1. 委託先法人IDフィルタ（5と空白のみ）
         before_count = len(df)
         df_filtered = df[(df['委託先法人ID'] == 5) | df['委託先法人ID'].isna()]
-        after_count = len(df_filtered)
-        logger.log(f"委託先法人IDフィルタ（5と空白のみ）: {before_count}件 → {after_count}件（除外: {before_count - after_count}件）")
+        logs.append(DetailedLogger.log_filter_result(before_count, len(df_filtered), "委託先法人ID（5と空白のみ）"))
 
         # 2. 入金予定日フィルタ（本日より前、本日除く）
         before_count = len(df_filtered)
@@ -80,49 +75,45 @@ def process_mirail_notification(
             df_filtered['入金予定日'].notna() &
             (df_filtered['入金予定日'] < today)
         ]
-        after_count = len(df_filtered)
-        logger.log(f"入金予定日フィルタ（本日より前）: {before_count}件 → {after_count}件（除外: {before_count - after_count}件）")
+        logs.append(DetailedLogger.log_filter_result(before_count, len(df_filtered), "入金予定日（本日より前）"))
 
         # 3. 入金予定金額フィルタ（2,3,5,12を除外）
         before_count = len(df_filtered)
         df_filtered = df_filtered[~df_filtered['入金予定金額'].isin([2, 3, 5, 12])]
-        after_count = len(df_filtered)
-        logger.log(f"入金予定金額フィルタ（2,3,5,12除外）: {before_count}件 → {after_count}件（除外: {before_count - after_count}件）")
+        logs.append(DetailedLogger.log_filter_result(before_count, len(df_filtered), "入金予定金額（2,3,5,12除外）"))
 
         # 4. 回収ランクフィルタ（弁護士介入のみ）
         before_count = len(df_filtered)
         df_filtered = df_filtered[df_filtered['回収ランク'] == '弁護士介入']
-        after_count = len(df_filtered)
-        logger.log(f"回収ランクフィルタ（弁護士介入のみ）: {before_count}件 → {after_count}件（除外: {before_count - after_count}件）")
+        logs.append(DetailedLogger.log_filter_result(before_count, len(df_filtered), "回収ランク（弁護士介入のみ）"))
 
         # 5. クライアントCDフィルタ
         before_count = len(df_filtered)
         if client_pattern == 'included':
             # 1,4,5を選択
             df_filtered = df_filtered[df_filtered['クライアントCD'].isin([1, 4, 5])]
-            logger.log(f"クライアントCDフィルタ（1,4,5を選択）: {before_count}件 → {len(df_filtered)}件（除外: {before_count - len(df_filtered)}件）")
+            logs.append(DetailedLogger.log_filter_result(before_count, len(df_filtered), "クライアントCD（1,4,5）"))
         else:
             # 1,4,5,10,40を除外
             df_filtered = df_filtered[~df_filtered['クライアントCD'].isin([1, 4, 5, 10, 40])]
-            logger.log(f"クライアントCDフィルタ（1,4,5,10,40を除外）: {before_count}件 → {len(df_filtered)}件（除外: {before_count - len(df_filtered)}件）")
+            logs.append(DetailedLogger.log_filter_result(before_count, len(df_filtered), "クライアントCD（1,4,5,10,40除外）"))
 
         # 6. 対象別住所チェック
         before_count = len(df_filtered)
         if target_type == 'contractor':
-            df_filtered = check_contractor_address(df_filtered, logger)
+            df_filtered = check_contractor_address(df_filtered, logs)
         elif target_type == 'guarantor':
-            df_filtered = check_guarantor_address(df_filtered, logger)
+            df_filtered = check_guarantor_address(df_filtered, logs)
         elif target_type == 'contact':
-            df_filtered = check_contact_address(df_filtered, logger)
+            df_filtered = check_contact_address(df_filtered, logs)
 
-        after_count = len(df_filtered)
-        logger.log(f"住所完全性チェック後: {before_count}件 → {after_count}件（除外: {before_count - after_count}件）")
+        logs.append(DetailedLogger.log_filter_result(before_count, len(df_filtered), "住所完全性チェック"))
 
         # 結果チェック
         if len(df_filtered) == 0:
             message = f"フィルタ条件に該当するデータが見つかりませんでした。"
-            logger.log(message)
-            return None, None, message, logger.get_logs()
+            logs.append(message)
+            return None, None, message, logs
 
         # ファイル名生成
         now = datetime.now()
@@ -131,30 +122,20 @@ def process_mirail_notification(
 
         # 成功メッセージ
         message = f"{target_name}{pattern_text}のリストを作成しました。出力件数: {len(df_filtered)}件"
-        logger.log(f"処理完了: 出力件数 {len(df_filtered)}件")
-        logger.log(f"出力ファイル名: {filename}")
+        logs.append(DetailedLogger.log_final_result(len(df_filtered)))
 
-        return df_filtered, filename, message, logger.get_logs()
+        return df_filtered, filename, message, logs
 
     except Exception as e:
         error_message = f"処理中にエラーが発生しました: {str(e)}"
-        logger.log(error_message)
-        return None, None, error_message, logger.get_logs()
+        logs.append(error_message)
+        return None, None, error_message, logs
 
 
-def check_contractor_address(df: pd.DataFrame, logger: DetailedLogger) -> pd.DataFrame:
+def check_contractor_address(df: pd.DataFrame, logs: List[str]) -> pd.DataFrame:
     """契約者の住所完全性チェック"""
-    logger.log("契約者住所完全性チェック:")
-
     # 列インデックス22-25（W-Z列）: 郵便番号、現住所1、現住所2、現住所3
     address_cols = df.columns[22:26].tolist()  # 0-indexedなので22から25まで
-
-    # 各列の空欄をチェック
-    for i, col in enumerate(address_cols):
-        null_count = df[col].isna().sum() + (df[col] == '').sum()
-        if null_count > 0:
-            col_name = ['郵便番号', '現住所1', '現住所2', '現住所3'][i]
-            logger.log(f"  - {col_name}空欄: {null_count}件")
 
     # いずれかの列が空欄（NaNまたは空文字）の行を除外
     valid_mask = True
@@ -164,9 +145,8 @@ def check_contractor_address(df: pd.DataFrame, logger: DetailedLogger) -> pd.Dat
     return df[valid_mask]
 
 
-def check_guarantor_address(df: pd.DataFrame, logger: DetailedLogger) -> pd.DataFrame:
+def check_guarantor_address(df: pd.DataFrame, logs: List[str]) -> pd.DataFrame:
     """保証人の住所完全性チェック"""
-    logger.log("保証人住所完全性チェック:")
 
     # 保証人1（列インデックス41-45）: AP-AT列
     g1_name_col = df.columns[41]  # AP列: 保証人１氏名
@@ -188,33 +168,17 @@ def check_guarantor_address(df: pd.DataFrame, logger: DetailedLogger) -> pd.Data
     for col in g1_address_cols:
         g1_complete = g1_complete & df[col].notna() & (df[col] != '')
 
-    # 保証人1の空欄数をログ
-    for i, col in enumerate(g1_address_cols):
-        null_count = df[col].isna().sum() + (df[col] == '').sum()
-        if null_count > 0:
-            col_name = ['郵便番号', '現住所1', '現住所2', '現住所3'][i]
-            logger.log(f"  - 保証人1{col_name}空欄: {null_count}件")
 
     # 保証人2が存在する行をチェック
     g2_exists = df[g2_name_col].notna() & (df[g2_name_col] != '')
     g2_count = g2_exists.sum()
 
     if g2_count > 0:
-        logger.log(f"  保証人2が存在: {g2_count}件")
-
         # 保証人2の住所完全性チェック
         g2_address_cols = [g2_postal, g2_addr1, g2_addr2, g2_addr3]
         g2_complete = True
         for col in g2_address_cols:
             g2_complete = g2_complete & df[col].notna() & (df[col] != '')
-
-        # 保証人2の空欄数をログ（保証人2が存在する行のみ）
-        for i, col in enumerate(g2_address_cols):
-            null_count = (df[g2_exists][col].isna().sum() +
-                         (df[g2_exists][col] == '').sum())
-            if null_count > 0:
-                col_name = ['郵便番号', '現住所1', '現住所2', '現住所3'][i]
-                logger.log(f"  - 保証人2{col_name}空欄: {null_count}件")
 
         # 保証人2が存在しない場合は保証人1の住所が完全であればOK
         # 保証人2が存在する場合は少なくとも一方の住所が完全であればOK
@@ -223,15 +187,11 @@ def check_guarantor_address(df: pd.DataFrame, logger: DetailedLogger) -> pd.Data
         # 保証人2が存在しない場合は保証人1の住所のみチェック
         valid_mask = g1_complete
 
-    excluded_count = (~valid_mask).sum()
-    logger.log(f"  両保証人とも住所不完全で除外: {excluded_count}件")
-
     return df[valid_mask]
 
 
-def check_contact_address(df: pd.DataFrame, logger: DetailedLogger) -> pd.DataFrame:
+def check_contact_address(df: pd.DataFrame, logs: List[str]) -> pd.DataFrame:
     """緊急連絡人の住所完全性チェック"""
-    logger.log("緊急連絡人住所完全性チェック:")
 
     # 緊急連絡人1（列インデックス）: BD, BF-BI列
     e1_name_col = df.columns[55]  # BD列: 緊急連絡人１氏名
@@ -253,41 +213,22 @@ def check_contact_address(df: pd.DataFrame, logger: DetailedLogger) -> pd.DataFr
     for col in e1_address_cols:
         e1_complete = e1_complete & df[col].notna() & (df[col] != '')
 
-    # 緊急連絡人1の空欄数をログ
-    for i, col in enumerate(e1_address_cols):
-        null_count = df[col].isna().sum() + (df[col] == '').sum()
-        if null_count > 0:
-            col_name = ['郵便番号', '現住所1', '現住所2', '現住所3'][i]
-            logger.log(f"  - 緊急連絡人1{col_name}空欄: {null_count}件")
 
     # 緊急連絡人2が存在する行をチェック
     e2_exists = df[e2_name_col].notna() & (df[e2_name_col] != '')
     e2_count = e2_exists.sum()
 
     if e2_count > 0:
-        logger.log(f"  緊急連絡人2が存在: {e2_count}件")
-
         # 緊急連絡人2の住所完全性チェック
         e2_address_cols = [e2_postal, e2_addr1, e2_addr2, e2_addr3]
         e2_complete = True
         for col in e2_address_cols:
             e2_complete = e2_complete & df[col].notna() & (df[col] != '')
 
-        # 緊急連絡人2の空欄数をログ（緊急連絡人2が存在する行のみ）
-        for i, col in enumerate(e2_address_cols):
-            null_count = (df[e2_exists][col].isna().sum() +
-                         (df[e2_exists][col] == '').sum())
-            if null_count > 0:
-                col_name = ['郵便番号', '現住所1', '現住所2', '現住所3'][i]
-                logger.log(f"  - 緊急連絡人2{col_name}空欄: {null_count}件")
-
         # 少なくとも一方の住所が完全であればOK
         valid_mask = e1_complete | (e2_exists & e2_complete) | (~e2_exists & e1_complete)
     else:
         # 緊急連絡人2が存在しない場合は緊急連絡人1の住所のみチェック
         valid_mask = e1_complete
-
-    excluded_count = (~valid_mask).sum()
-    logger.log(f"  両緊急連絡人とも住所不完全で除外: {excluded_count}件")
 
     return df[valid_mask]

--- a/processors/mirail_notification.py
+++ b/processors/mirail_notification.py
@@ -1,0 +1,293 @@
+"""
+ミライル（フェイス封筒）用リスト作成プロセッサー
+契約者、保証人、連絡人の郵送用リストを生成する
+"""
+import pandas as pd
+import numpy as np
+import io
+from datetime import datetime
+from typing import Tuple, Optional
+from processors.common.detailed_logger import DetailedLogger
+
+
+def read_csv_auto_encoding(file_content: bytes) -> pd.DataFrame:
+    """アップロードされたCSVファイルを自動エンコーディング判定で読み込み"""
+    encodings = ['utf-8', 'utf-8-sig', 'shift_jis', 'cp932']
+
+    for enc in encodings:
+        try:
+            return pd.read_csv(io.BytesIO(file_content), encoding=enc, dtype=str)
+        except Exception:
+            continue
+
+    raise ValueError("CSVファイルの読み込みに失敗しました。エンコーディングを確認してください。")
+
+
+def process_mirail_notification(
+    file_content: bytes,
+    target_type: str,  # 'contractor', 'guarantor', 'contact'
+    client_pattern: str  # 'included' or 'excluded'
+) -> Tuple[Optional[pd.DataFrame], Optional[str], str, list]:
+    """
+    ミライル（フェイス封筒）用リストを生成する
+
+    Args:
+        file_content: ContractList*.csvのバイトデータ
+        target_type: 対象者タイプ（contractor/guarantor/contact）
+        client_pattern: クライアントCDパターン（included=1,4,5 / excluded=1,4,5以外）
+
+    Returns:
+        (result_df, filename, message, logs)
+        0件の場合: (None, None, エラーメッセージ, logs)
+    """
+    logger = DetailedLogger()
+
+    try:
+        # 処理開始
+        target_name_map = {
+            'contractor': '契約者',
+            'guarantor': '保証人',
+            'contact': '連絡人'
+        }
+        target_name = target_name_map.get(target_type, target_type)
+        pattern_text = "（1,4,5）" if client_pattern == 'included' else "（1,4,5以外）"
+
+        logger.log(f"処理開始: {target_name}{pattern_text}")
+
+        # CSV読み込み
+        logger.log("CSVファイル読み込み中...")
+        df = read_csv_auto_encoding(file_content)
+        logger.log(f"入力データ: {len(df)}件, {len(df.columns)}列")
+
+        # データ型変換
+        logger.log("データ型変換中...")
+        df['委託先法人ID'] = pd.to_numeric(df['委託先法人ID'], errors='coerce')
+        df['クライアントCD'] = pd.to_numeric(df['クライアントCD'], errors='coerce')
+        df['入金予定金額'] = pd.to_numeric(df['入金予定金額'], errors='coerce')
+        df['入金予定日'] = pd.to_datetime(df['入金予定日'], errors='coerce', format='%Y/%m/%d')
+
+        # 1. 委託先法人IDフィルタ（5と空白のみ）
+        before_count = len(df)
+        df_filtered = df[(df['委託先法人ID'] == 5) | df['委託先法人ID'].isna()]
+        after_count = len(df_filtered)
+        logger.log(f"委託先法人IDフィルタ（5と空白のみ）: {before_count}件 → {after_count}件（除外: {before_count - after_count}件）")
+
+        # 2. 入金予定日フィルタ（本日より前、本日除く）
+        before_count = len(df_filtered)
+        today = pd.Timestamp(datetime.now().date())
+        # 入金予定日がNaTでない かつ 本日より前
+        df_filtered = df_filtered[
+            df_filtered['入金予定日'].notna() &
+            (df_filtered['入金予定日'] < today)
+        ]
+        after_count = len(df_filtered)
+        logger.log(f"入金予定日フィルタ（本日より前）: {before_count}件 → {after_count}件（除外: {before_count - after_count}件）")
+
+        # 3. 入金予定金額フィルタ（2,3,5,12を除外）
+        before_count = len(df_filtered)
+        df_filtered = df_filtered[~df_filtered['入金予定金額'].isin([2, 3, 5, 12])]
+        after_count = len(df_filtered)
+        logger.log(f"入金予定金額フィルタ（2,3,5,12除外）: {before_count}件 → {after_count}件（除外: {before_count - after_count}件）")
+
+        # 4. 回収ランクフィルタ（弁護士介入のみ）
+        before_count = len(df_filtered)
+        df_filtered = df_filtered[df_filtered['回収ランク'] == '弁護士介入']
+        after_count = len(df_filtered)
+        logger.log(f"回収ランクフィルタ（弁護士介入のみ）: {before_count}件 → {after_count}件（除外: {before_count - after_count}件）")
+
+        # 5. クライアントCDフィルタ
+        before_count = len(df_filtered)
+        if client_pattern == 'included':
+            # 1,4,5を選択
+            df_filtered = df_filtered[df_filtered['クライアントCD'].isin([1, 4, 5])]
+            logger.log(f"クライアントCDフィルタ（1,4,5を選択）: {before_count}件 → {len(df_filtered)}件（除外: {before_count - len(df_filtered)}件）")
+        else:
+            # 1,4,5,10,40を除外
+            df_filtered = df_filtered[~df_filtered['クライアントCD'].isin([1, 4, 5, 10, 40])]
+            logger.log(f"クライアントCDフィルタ（1,4,5,10,40を除外）: {before_count}件 → {len(df_filtered)}件（除外: {before_count - len(df_filtered)}件）")
+
+        # 6. 対象別住所チェック
+        before_count = len(df_filtered)
+        if target_type == 'contractor':
+            df_filtered = check_contractor_address(df_filtered, logger)
+        elif target_type == 'guarantor':
+            df_filtered = check_guarantor_address(df_filtered, logger)
+        elif target_type == 'contact':
+            df_filtered = check_contact_address(df_filtered, logger)
+
+        after_count = len(df_filtered)
+        logger.log(f"住所完全性チェック後: {before_count}件 → {after_count}件（除外: {before_count - after_count}件）")
+
+        # 結果チェック
+        if len(df_filtered) == 0:
+            message = f"フィルタ条件に該当するデータが見つかりませんでした。"
+            logger.log(message)
+            return None, None, message, logger.get_logs()
+
+        # ファイル名生成
+        now = datetime.now()
+        pattern_suffix = "" if client_pattern == 'included' else "以外"
+        filename = f"{now.strftime('%m%d')}{target_name}（1,4,5{pattern_suffix}）.xlsx"
+
+        # 成功メッセージ
+        message = f"{target_name}{pattern_text}のリストを作成しました。出力件数: {len(df_filtered)}件"
+        logger.log(f"処理完了: 出力件数 {len(df_filtered)}件")
+        logger.log(f"出力ファイル名: {filename}")
+
+        return df_filtered, filename, message, logger.get_logs()
+
+    except Exception as e:
+        error_message = f"処理中にエラーが発生しました: {str(e)}"
+        logger.log(error_message)
+        return None, None, error_message, logger.get_logs()
+
+
+def check_contractor_address(df: pd.DataFrame, logger: DetailedLogger) -> pd.DataFrame:
+    """契約者の住所完全性チェック"""
+    logger.log("契約者住所完全性チェック:")
+
+    # 列インデックス22-25（W-Z列）: 郵便番号、現住所1、現住所2、現住所3
+    address_cols = df.columns[22:26].tolist()  # 0-indexedなので22から25まで
+
+    # 各列の空欄をチェック
+    for i, col in enumerate(address_cols):
+        null_count = df[col].isna().sum() + (df[col] == '').sum()
+        if null_count > 0:
+            col_name = ['郵便番号', '現住所1', '現住所2', '現住所3'][i]
+            logger.log(f"  - {col_name}空欄: {null_count}件")
+
+    # いずれかの列が空欄（NaNまたは空文字）の行を除外
+    valid_mask = True
+    for col in address_cols:
+        valid_mask = valid_mask & df[col].notna() & (df[col] != '')
+
+    return df[valid_mask]
+
+
+def check_guarantor_address(df: pd.DataFrame, logger: DetailedLogger) -> pd.DataFrame:
+    """保証人の住所完全性チェック"""
+    logger.log("保証人住所完全性チェック:")
+
+    # 保証人1（列インデックス41-45）: AP-AT列
+    g1_name_col = df.columns[41]  # AP列: 保証人１氏名
+    g1_postal = df.columns[42]    # AQ列: 郵便番号
+    g1_addr1 = df.columns[43]     # AR列: 現住所1
+    g1_addr2 = df.columns[44]     # AS列: 現住所2
+    g1_addr3 = df.columns[45]     # AT列: 現住所3
+
+    # 保証人2（列インデックス48-52）: AW-BA列
+    g2_name_col = df.columns[48]  # AW列: 保証人２氏名
+    g2_postal = df.columns[49]    # AX列: 郵便番号
+    g2_addr1 = df.columns[50]     # AY列: 現住所1
+    g2_addr2 = df.columns[51]     # AZ列: 現住所2
+    g2_addr3 = df.columns[52]     # BA列: 現住所3
+
+    # 保証人1の住所完全性チェック
+    g1_address_cols = [g1_postal, g1_addr1, g1_addr2, g1_addr3]
+    g1_complete = True
+    for col in g1_address_cols:
+        g1_complete = g1_complete & df[col].notna() & (df[col] != '')
+
+    # 保証人1の空欄数をログ
+    for i, col in enumerate(g1_address_cols):
+        null_count = df[col].isna().sum() + (df[col] == '').sum()
+        if null_count > 0:
+            col_name = ['郵便番号', '現住所1', '現住所2', '現住所3'][i]
+            logger.log(f"  - 保証人1{col_name}空欄: {null_count}件")
+
+    # 保証人2が存在する行をチェック
+    g2_exists = df[g2_name_col].notna() & (df[g2_name_col] != '')
+    g2_count = g2_exists.sum()
+
+    if g2_count > 0:
+        logger.log(f"  保証人2が存在: {g2_count}件")
+
+        # 保証人2の住所完全性チェック
+        g2_address_cols = [g2_postal, g2_addr1, g2_addr2, g2_addr3]
+        g2_complete = True
+        for col in g2_address_cols:
+            g2_complete = g2_complete & df[col].notna() & (df[col] != '')
+
+        # 保証人2の空欄数をログ（保証人2が存在する行のみ）
+        for i, col in enumerate(g2_address_cols):
+            null_count = (df[g2_exists][col].isna().sum() +
+                         (df[g2_exists][col] == '').sum())
+            if null_count > 0:
+                col_name = ['郵便番号', '現住所1', '現住所2', '現住所3'][i]
+                logger.log(f"  - 保証人2{col_name}空欄: {null_count}件")
+
+        # 保証人2が存在しない場合は保証人1の住所が完全であればOK
+        # 保証人2が存在する場合は少なくとも一方の住所が完全であればOK
+        valid_mask = g1_complete | (g2_exists & g2_complete) | (~g2_exists & g1_complete)
+    else:
+        # 保証人2が存在しない場合は保証人1の住所のみチェック
+        valid_mask = g1_complete
+
+    excluded_count = (~valid_mask).sum()
+    logger.log(f"  両保証人とも住所不完全で除外: {excluded_count}件")
+
+    return df[valid_mask]
+
+
+def check_contact_address(df: pd.DataFrame, logger: DetailedLogger) -> pd.DataFrame:
+    """緊急連絡人の住所完全性チェック"""
+    logger.log("緊急連絡人住所完全性チェック:")
+
+    # 緊急連絡人1（列インデックス）: BD, BF-BI列
+    e1_name_col = df.columns[55]  # BD列: 緊急連絡人１氏名
+    e1_postal = df.columns[57]    # BF列: 郵便番号
+    e1_addr1 = df.columns[58]     # BG列: 現住所1
+    e1_addr2 = df.columns[59]     # BH列: 現住所2
+    e1_addr3 = df.columns[60]     # BI列: 現住所3
+
+    # 緊急連絡人2（列インデックス）: BK-BO列
+    e2_name_col = df.columns[62]  # BK列: 緊急連絡人２氏名
+    e2_postal = df.columns[63]    # BL列: 郵便番号
+    e2_addr1 = df.columns[64]     # BM列: 現住所1
+    e2_addr2 = df.columns[65]     # BN列: 現住所2
+    e2_addr3 = df.columns[66]     # BO列: 現住所3
+
+    # 緊急連絡人1の住所完全性チェック
+    e1_address_cols = [e1_postal, e1_addr1, e1_addr2, e1_addr3]
+    e1_complete = True
+    for col in e1_address_cols:
+        e1_complete = e1_complete & df[col].notna() & (df[col] != '')
+
+    # 緊急連絡人1の空欄数をログ
+    for i, col in enumerate(e1_address_cols):
+        null_count = df[col].isna().sum() + (df[col] == '').sum()
+        if null_count > 0:
+            col_name = ['郵便番号', '現住所1', '現住所2', '現住所3'][i]
+            logger.log(f"  - 緊急連絡人1{col_name}空欄: {null_count}件")
+
+    # 緊急連絡人2が存在する行をチェック
+    e2_exists = df[e2_name_col].notna() & (df[e2_name_col] != '')
+    e2_count = e2_exists.sum()
+
+    if e2_count > 0:
+        logger.log(f"  緊急連絡人2が存在: {e2_count}件")
+
+        # 緊急連絡人2の住所完全性チェック
+        e2_address_cols = [e2_postal, e2_addr1, e2_addr2, e2_addr3]
+        e2_complete = True
+        for col in e2_address_cols:
+            e2_complete = e2_complete & df[col].notna() & (df[col] != '')
+
+        # 緊急連絡人2の空欄数をログ（緊急連絡人2が存在する行のみ）
+        for i, col in enumerate(e2_address_cols):
+            null_count = (df[e2_exists][col].isna().sum() +
+                         (df[e2_exists][col] == '').sum())
+            if null_count > 0:
+                col_name = ['郵便番号', '現住所1', '現住所2', '現住所3'][i]
+                logger.log(f"  - 緊急連絡人2{col_name}空欄: {null_count}件")
+
+        # 少なくとも一方の住所が完全であればOK
+        valid_mask = e1_complete | (e2_exists & e2_complete) | (~e2_exists & e1_complete)
+    else:
+        # 緊急連絡人2が存在しない場合は緊急連絡人1の住所のみチェック
+        valid_mask = e1_complete
+
+    excluded_count = (~valid_mask).sum()
+    logger.log(f"  両緊急連絡人とも住所不完全で除外: {excluded_count}件")
+
+    return df[valid_mask]

--- a/processors/mirail_notification.py
+++ b/processors/mirail_notification.py
@@ -56,7 +56,7 @@ def process_mirail_notification(
         df = read_csv_auto_encoding(file_content)
         logs.append(DetailedLogger.log_initial_load(len(df)))
 
-        # データ型変換
+        # データ型変換（列名でアクセス - より安全）
         df['委託先法人ID'] = pd.to_numeric(df['委託先法人ID'], errors='coerce')
         df['クライアントCD'] = pd.to_numeric(df['クライアントCD'], errors='coerce')
         df['入金予定金額'] = pd.to_numeric(df['入金予定金額'], errors='coerce')
@@ -82,10 +82,10 @@ def process_mirail_notification(
         df_filtered = df_filtered[~df_filtered['入金予定金額'].isin([2, 3, 5, 12])]
         logs.append(DetailedLogger.log_filter_result(before_count, len(df_filtered), "入金予定金額（2,3,5,12除外）"))
 
-        # 4. 回収ランクフィルタ（弁護士介入のみ）
+        # 4. 回収ランクフィルタ（弁護士介入を除外）
         before_count = len(df_filtered)
-        df_filtered = df_filtered[df_filtered['回収ランク'] == '弁護士介入']
-        logs.append(DetailedLogger.log_filter_result(before_count, len(df_filtered), "回収ランク（弁護士介入のみ）"))
+        df_filtered = df_filtered[df_filtered['回収ランク'] != '弁護士介入']
+        logs.append(DetailedLogger.log_filter_result(before_count, len(df_filtered), "回収ランク（弁護士介入除外）"))
 
         # 5. クライアントCDフィルタ
         before_count = len(df_filtered)

--- a/screens/notification/mirail.py
+++ b/screens/notification/mirail.py
@@ -30,7 +30,7 @@ def render_mirail_notification(target_type: str, client_pattern: str):
             "委託先法人ID = 5と空白のみ選択",
             "入金予定日 < 本日（本日を除く）",
             "入金予定金額 = 2, 3, 5, 12を除外",
-            "回収ランク = 弁護士介入のみ選択"
+            "回収ランク ≠ 弁護士介入（除外）"
         ]
 
         # クライアントCDフィルタ

--- a/screens/notification/mirail.py
+++ b/screens/notification/mirail.py
@@ -6,6 +6,7 @@ import streamlit as st
 import pandas as pd
 import io
 from openpyxl import Workbook
+from openpyxl.styles import Font
 from components.common_ui import display_filter_conditions, display_processing_logs
 from processors.mirail_notification import process_mirail_notification
 
@@ -83,25 +84,34 @@ def render_mirail_notification(target_type: str, client_pattern: str):
                         with st.expander(f"📊 データプレビュー（先頭10件）", expanded=True):
                             st.dataframe(result_df.head(10))
 
-                        # Excel形式でダウンロード（入力CSVと同じ形式、スタイルなし）
+                        # Excel形式でダウンロード（游ゴシック 12pt）
                         output = io.BytesIO()
 
-                        # openpyxlで直接ワークブックを作成（スタイル適用を避ける）
+                        # openpyxlで直接ワークブックを作成
                         wb = Workbook()
                         ws = wb.active
                         ws.title = 'Sheet1'
 
-                        # ヘッダーを書き込み
-                        for col_num, column_title in enumerate(result_df.columns, 1):
-                            ws.cell(row=1, column=col_num, value=column_title)
+                        # フォント設定（游ゴシック Regular 12pt、罫線なし）
+                        custom_font = Font(
+                            name='游ゴシック',  # Yu Gothic / 游ゴシック体 / YuGothic
+                            size=12,
+                            bold=False
+                        )
 
-                        # データを書き込み
+                        # ヘッダーを書き込み（フォント適用）
+                        for col_num, column_title in enumerate(result_df.columns, 1):
+                            cell = ws.cell(row=1, column=col_num, value=column_title)
+                            cell.font = custom_font
+
+                        # データを書き込み（フォント適用）
                         for row_num, row_data in enumerate(result_df.values, 2):
                             for col_num, cell_value in enumerate(row_data, 1):
                                 # NaNやNoneの処理
                                 if pd.isna(cell_value):
                                     cell_value = ''
-                                ws.cell(row=row_num, column=col_num, value=cell_value)
+                                cell = ws.cell(row=row_num, column=col_num, value=cell_value)
+                                cell.font = custom_font
 
                         # 保存
                         wb.save(output)

--- a/screens/notification/mirail.py
+++ b/screens/notification/mirail.py
@@ -93,6 +93,7 @@ def render_mirail_notification(target_type: str, client_pattern: str):
                             data=output.getvalue(),
                             file_name=filename,
                             mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                            type="primary",
                             key=f"download_mirail_{target_type}_{client_pattern}"
                         )
                     else:

--- a/screens/notification/mirail.py
+++ b/screens/notification/mirail.py
@@ -101,8 +101,6 @@ def render_mirail_notification(target_type: str, client_pattern: str):
 
                 except Exception as e:
                     st.error(f"処理中にエラーが発生しました: {str(e)}")
-    else:
-        st.info("👆 CSVファイルをアップロードしてください")
 
 
 # app.pyから呼ばれる6つの関数

--- a/screens/notification/mirail.py
+++ b/screens/notification/mirail.py
@@ -1,0 +1,136 @@
+"""
+ミライル（フェイス封筒）差込み用リスト画面モジュール
+契約者、保証人、連絡人の郵送用リストを作成する画面
+"""
+import streamlit as st
+import pandas as pd
+import io
+from components.common_ui import display_filter_conditions, display_processing_logs
+from processors.mirail_notification import process_mirail_notification
+
+
+def render_mirail_notification(target_type: str, client_pattern: str):
+    """ミライル（フェイス封筒）共通レンダリング処理"""
+
+    # タイトル設定
+    target_name_map = {
+        'contractor': '契約者',
+        'guarantor': '保証人',
+        'contact': '連絡人'
+    }
+    target_name = target_name_map.get(target_type, target_type)
+    pattern_text = "（1,4,5）" if client_pattern == 'included' else "（1,4,5以外）"
+
+    st.title("📝 ミライル（フェイス封筒）")
+    st.subheader(f"{target_name}{pattern_text}のリストを作成")
+
+    # フィルタ条件表示
+    with st.expander("📋 フィルタ条件", expanded=True):
+        base_conditions = [
+            "委託先法人ID = 5と空白のみ選択",
+            "入金予定日 < 本日（本日を除く）",
+            "入金予定金額 = 2, 3, 5, 12を除外",
+            "回収ランク = 弁護士介入のみ選択"
+        ]
+
+        # クライアントCDフィルタ
+        if client_pattern == 'included':
+            base_conditions.append("クライアントCD = 1, 4, 5を選択")
+        else:
+            base_conditions.append("クライアントCD ≠ 1, 4, 5, 10, 40（すべて除外）")
+
+        # 住所フィルタ
+        if target_type == 'contractor':
+            base_conditions.append("契約者住所（郵便番号・現住所1・2・3）がすべて入力されている")
+        elif target_type == 'guarantor':
+            base_conditions.append("保証人1または保証人2の住所が完全（少なくとも一方の郵送が可能）")
+        else:  # contact
+            base_conditions.append("緊急連絡人1または緊急連絡人2の住所が完全（少なくとも一方の郵送が可能）")
+
+        display_filter_conditions(base_conditions)
+
+    # ファイルアップロード
+    st.markdown("### 📂 ファイルアップロード")
+    uploaded_file = st.file_uploader(
+        "ContractList*.csvファイルを選択してください",
+        type=['csv'],
+        key=f"mirail_{target_type}_{client_pattern}"
+    )
+
+    if uploaded_file is not None:
+        # 処理実行ボタン
+        if st.button("🚀 処理を実行", type="primary", key=f"process_mirail_{target_type}_{client_pattern}"):
+            with st.spinner("処理中..."):
+                try:
+                    # ファイル読み込み
+                    file_content = uploaded_file.read()
+
+                    # プロセッサー実行
+                    result_df, filename, message, logs = process_mirail_notification(
+                        file_content, target_type, client_pattern
+                    )
+
+                    # ログ表示
+                    display_processing_logs(logs)
+
+                    # 結果処理
+                    if result_df is not None and len(result_df) > 0:
+                        # 成功メッセージ
+                        st.success(message)
+
+                        # データプレビュー
+                        with st.expander(f"📊 データプレビュー（先頭10件）", expanded=True):
+                            st.dataframe(result_df.head(10))
+
+                        # Excel形式でダウンロード
+                        output = io.BytesIO()
+                        with pd.ExcelWriter(output, engine='openpyxl') as writer:
+                            result_df.to_excel(writer, index=False, sheet_name='Sheet1')
+                        output.seek(0)
+
+                        st.download_button(
+                            label=f"📥 {filename}をダウンロード",
+                            data=output.getvalue(),
+                            file_name=filename,
+                            mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                            key=f"download_mirail_{target_type}_{client_pattern}"
+                        )
+                    else:
+                        # エラーメッセージ（0件の場合）
+                        st.error(message)
+
+                except Exception as e:
+                    st.error(f"処理中にエラーが発生しました: {str(e)}")
+    else:
+        st.info("👆 CSVファイルをアップロードしてください")
+
+
+# app.pyから呼ばれる6つの関数
+def show_mirail_contractor_145():
+    """契約者（1,4,5）画面"""
+    render_mirail_notification('contractor', 'included')
+
+
+def show_mirail_contractor_not145():
+    """契約者（1,4,5以外）画面"""
+    render_mirail_notification('contractor', 'excluded')
+
+
+def show_mirail_guarantor_145():
+    """保証人（1,4,5）画面"""
+    render_mirail_notification('guarantor', 'included')
+
+
+def show_mirail_guarantor_not145():
+    """保証人（1,4,5以外）画面"""
+    render_mirail_notification('guarantor', 'excluded')
+
+
+def show_mirail_contact_145():
+    """連絡人（1,4,5）画面"""
+    render_mirail_notification('contact', 'included')
+
+
+def show_mirail_contact_not145():
+    """連絡人（1,4,5以外）画面"""
+    render_mirail_notification('contact', 'excluded')

--- a/screens/notification/mirail.py
+++ b/screens/notification/mirail.py
@@ -5,6 +5,7 @@
 import streamlit as st
 import pandas as pd
 import io
+import openpyxl.styles
 from components.common_ui import display_filter_conditions, display_processing_logs
 from processors.mirail_notification import process_mirail_notification
 
@@ -82,10 +83,19 @@ def render_mirail_notification(target_type: str, client_pattern: str):
                         with st.expander(f"📊 データプレビュー（先頭10件）", expanded=True):
                             st.dataframe(result_df.head(10))
 
-                        # Excel形式でダウンロード
+                        # Excel形式でダウンロード（スタイルなし）
                         output = io.BytesIO()
                         with pd.ExcelWriter(output, engine='openpyxl') as writer:
                             result_df.to_excel(writer, index=False, sheet_name='Sheet1')
+
+                            # スタイルを削除してシンプルな出力に
+                            worksheet = writer.sheets['Sheet1']
+                            # すべてのセルのスタイルをリセット
+                            for row in worksheet.iter_rows():
+                                for cell in row:
+                                    cell.font = openpyxl.styles.Font(bold=False)
+                                    cell.border = openpyxl.styles.Border()
+
                         output.seek(0)
 
                         st.download_button(

--- a/screens/notification/mirail.py
+++ b/screens/notification/mirail.py
@@ -88,12 +88,16 @@ def render_mirail_notification(target_type: str, client_pattern: str):
                         with pd.ExcelWriter(output, engine='openpyxl') as writer:
                             result_df.to_excel(writer, index=False, sheet_name='Sheet1')
 
-                            # スタイルを削除してシンプルな出力に
+                            # フォント設定（游ゴシック Regular 12pt）
                             worksheet = writer.sheets['Sheet1']
-                            # すべてのセルのスタイルをリセット
+                            # すべてのセルのスタイルを設定
                             for row in worksheet.iter_rows():
                                 for cell in row:
-                                    cell.font = openpyxl.styles.Font(bold=False)
+                                    cell.font = openpyxl.styles.Font(
+                                        name='游ゴシック',  # Yu Gothic / 游ゴシック体 / YuGothic
+                                        size=12,
+                                        bold=False
+                                    )
                                     cell.border = openpyxl.styles.Border()
 
                         output.seek(0)


### PR DESCRIPTION
## 概要
「📝 差込み用リスト作成」セクションに「ミライル（フェイス封筒）」機能を追加しました。
郵送用の差込みリストをExcel形式で生成する機能です。

## 主な機能
- 契約者、保証人、連絡人の3タイプ×2パターン（計6種類）のリスト生成
- クライアントCD（1,4,5 / 1,4,5以外）によるフィルタリング
- 住所完全性チェック（郵送可能なレコードのみ抽出）
- Excel形式での出力（游ゴシック 12pt）

## フィルタリング条件
- 委託先法人ID: 5と空白のみ選択
- 入金予定日: 本日より前（本日除く）
- 入金予定金額: 2, 3, 5, 12を除外
- 回収ランク: 弁護士介入を除外
- クライアントCD: 1,4,5を選択 / 1,4,5,10,40を除外
- 住所: 郵送可能な完全な住所のみ（空欄除外）

## 変更内容
- ✅ 新規プロセッサー: `processors/mirail_notification.py`
- ✅ 新規画面モジュール: `screens/notification/mirail.py`
- ✅ サイドバーに「ミライル（フェイス封筒）」サブカテゴリ追加
- ✅ メインアプリにマッピング追加

## 修正履歴
- DetailedLogger使用方法を修正（静的メソッドを正しく使用）
- 回収ランクフィルタのロジック修正（弁護士介入を除外）
- Excel出力のフォント設定（游ゴシック 12pt）

## テスト
- ✅ CSVファイルアップロード
- ✅ フィルタリング処理
- ✅ Excel形式でのダウンロード
- ✅ 0件時のエラーメッセージ表示

🤖 Generated with Claude Code