### PR TITLE
fix: フェイス催告書保証人2の列ずれを修正

### DIFF
--- a/processors/faith_notification.py
+++ b/processors/faith_notification.py
@@ -340,13 +340,13 @@ def process_guarantor(df: pd.DataFrame) -> Tuple[pd.DataFrame, list]:
         })
         results.append(g1_result)
     
-    # 保証人2の処理（AX-BE列 = 49-56列目）
+    # 保証人2の処理（AW-BA列 = 48-52列目）
     guarantor2_df = df[
-        df.iloc[:, 50].notna() & (df.iloc[:, 50] != '') &  # 郵便番号（AY）
-        df.iloc[:, 51].notna() & (df.iloc[:, 51] != '') &  # 現住所1（AZ）
-        df.iloc[:, 52].notna() & (df.iloc[:, 52] != '') &  # 現住所2（BA）
-        df.iloc[:, 53].notna() & (df.iloc[:, 53] != '') &  # 現住所3（BB）
-        df.iloc[:, 49].notna() & (df.iloc[:, 49] != '')    # 保証人名（AX）
+        df.iloc[:, 49].notna() & (df.iloc[:, 49] != '') &  # 郵便番号（AX）
+        df.iloc[:, 50].notna() & (df.iloc[:, 50] != '') &  # 現住所1（AY）
+        df.iloc[:, 51].notna() & (df.iloc[:, 51] != '') &  # 現住所2（AZ）
+        df.iloc[:, 52].notna() & (df.iloc[:, 52] != '') &  # 現住所3（BA）
+        df.iloc[:, 48].notna() & (df.iloc[:, 48] != '')    # 保証人名（AW）
     ]
     
     log = DetailedLogger.log_filter_result(before_count, len(guarantor2_df), "保証人2（住所完全）")
@@ -365,11 +365,11 @@ def process_guarantor(df: pd.DataFrame) -> Tuple[pd.DataFrame, list]:
         g2_result = pd.DataFrame({
             '管理番号': guarantor2_df.iloc[:, 0],
             '契約者氏名': guarantor2_df.iloc[:, 20],
-            '連帯保証人名': guarantor2_df.iloc[:, 49],    # AX列
-            '郵便番号': guarantor2_df.iloc[:, 50],        # AY列
-            '現住所1': guarantor2_df.iloc[:, 51],         # AZ列
-            '現住所2': guarantor2_df.iloc[:, 52],         # BA列
-            '現住所3': guarantor2_df.iloc[:, 53],         # BB列
+            '連帯保証人名': guarantor2_df.iloc[:, 48],    # AW列
+            '郵便番号': guarantor2_df.iloc[:, 49],        # AX列
+            '現住所1': guarantor2_df.iloc[:, 50],         # AY列
+            '現住所2': guarantor2_df.iloc[:, 51],         # AZ列
+            '現住所3': guarantor2_df.iloc[:, 52],         # BA列
             '滞納残債': guarantor2_df.iloc[:, 71],
             '物件住所1': guarantor2_df.iloc[:, 92],
             '物件住所2': guarantor2_df.iloc[:, 93],

--- a/screens/notification/faith.py
+++ b/screens/notification/faith.py
@@ -33,7 +33,7 @@ def render_single_button_process(target_type: str, occupancy_status: str, filter
     with st.expander("📋 フィルタ条件", expanded=True):
         base_conditions = [
             "委託先法人id = 1, 2, 3, 4",
-            "入金予定日 < 本日",
+            "入金予定日 < 本日（空白含む）",
             "入金予定金額 = 2, 3, 5を除外",
             f"入居ステータス = {occupancy_status}"
         ]


### PR DESCRIPTION
## 問題

フェイス催告書の連帯保証人②が正しく抽出されない問題がありました。

- **期待**: 23件
- **実際**: 9件（14件不足）

細谷様作成のリストと比較して件数が不一致でした。

## 原因

保証人2の列インデックスが1つずれていました。

- 保証人名: AX列（郵便番号）を参照 → **正しくはAW列**
- 郵便番号: AY列を参照 → 正しくはAX列
- 現住所1-3: AZ-BB列を参照 → 正しくはAY-BA列

このため、保証人2の氏名があっても郵便番号が空欄の場合に抽出されませんでした。

## 修正内容

### 1. `processors/faith_notification.py`
保証人2のフィルタリングとマッピングを修正：
- すべての列インデックスを-1（49→48, 50→49, 51→50, 52→51, 53→52）
- フィルタリング条件（343-350行目）
- データマッピング（368-372行目）

### 2. `screens/notification/faith.py`
フィルタ条件の表示を正確に修正：
- 「入金予定日 < 本日」→「入金予定日 < 本日（空白含む）」

## 影響範囲

フェイス連帯保証人の3パターンすべて：
- ✅ 退去済み（9件 → 23件）
- ✅ 入居中/訴訟中
- ✅ 入居中/訴訟対象外

## テスト方法

細谷様に以下を確認いただく：
1. 「退去済み保証人」リストを再出力
2. ②の件数が23件になることを確認
3. 細谷様作成リストと内容が一致することを確認

## 関連資料

- 元データ: `ContractList_20250925115419.csv`
- 細谷様リスト: `フェイス退去済み保証人（細谷作成）.xlsx`（①383件、②23件）
- 修正前システム出力: `0925フェイス差込み用リスト（連帯保証人【退去済み】）確認が必要.csv`（①383件、②9件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)